### PR TITLE
Switch to clap for argument parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "anstyle"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
+
+[[package]]
 name = "ar_archive_writer"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12,10 +18,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "lexopt"
-version = "0.3.1"
+name = "clap"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa0e2a1fcbe2f6be6c42e342259976206b383122fc152e872795338b5a3f3a7"
+checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "memchr"
@@ -42,10 +68,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "winlib"
 version = "0.2.1"
 dependencies = [
  "ar_archive_writer",
- "lexopt",
+ "clap",
  "object 0.37.1",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,19 @@ repository = "https://github.com/ChrisDenton/winlibtools"
 
 [dependencies]
 ar_archive_writer = "0.4.2"
-lexopt = "0.3.1"
+
+[dependencies.clap]
+version = "4.5.41"
+default-features = false
+features = ["std", "help", "suggestions", "usage"]
 
 [dependencies.object]
 version = "0.37.1"
 default-features = false
 features = ["read_core", "archive", "coff", "unaligned"]
+
+[lints.clippy]
+from_str_radix_10 = "allow"
 
 [profile.release]
 lto = "thin"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+use clap::ArgAction;
+use core::num::ParseIntError;
 use object::coff::{CoffFile, ImportFile};
 use object::pe::ImageFileHeader;
 use object::read::archive::ArchiveFile;
@@ -5,7 +7,7 @@ use std::error::Error;
 use std::ffi::{OsStr, OsString};
 use std::fmt;
 use std::fs;
-use std::io::{self, Cursor, Write};
+use std::io::{self, Cursor};
 use std::process::ExitCode;
 
 #[derive(Debug)]
@@ -34,17 +36,17 @@ struct CreateOptions {
 }
 
 fn create_lib(
-    lib_path: &OsStr,
+    from_lib: &OsStr,
     out_lib: &OsStr,
     options: &CreateOptions,
 ) -> Result<(), WinlibError> {
     let extracted_lib = options.save_excluded.as_deref();
-    let data = fs::read(&lib_path).map_err(|e| WinlibError::IoError {
-        msg: format!("cannot read {}", lib_path.display()),
+    let data = fs::read(&from_lib).map_err(|e| WinlibError::IoError {
+        msg: format!("cannot read {}", from_lib.display()),
         cause: e,
     })?;
     let archive = ArchiveFile::parse(&*data).map_err(|e| WinlibError::ObjectError {
-        msg: format!("not a recognised archive file: {}", lib_path.display()),
+        msg: format!("not a recognised archive file: {}", from_lib.display()),
         cause: e,
     })?;
 
@@ -53,14 +55,14 @@ fn create_lib(
 
     for member in archive.members() {
         let member = member.map_err(|e| WinlibError::ObjectError {
-            msg: format!("could not read archive member in {}", lib_path.display()),
+            msg: format!("could not read archive member in {}", from_lib.display()),
             cause: e,
         })?;
         let data = member.data(&*data).map_err(|e| WinlibError::ObjectError {
             msg: format!(
                 "could not get data from archive member at {:#x} in {}",
                 member.file_range().0,
-                lib_path.display()
+                from_lib.display()
             ),
             cause: e,
         })?;
@@ -76,7 +78,7 @@ fn create_lib(
                             msg: format!(
                                 "unable to retrieve section name at {:#x} in {}",
                                 member.file_range().0,
-                                lib_path.display()
+                                from_lib.display()
                             ),
                             cause: e,
                         })?;
@@ -95,7 +97,7 @@ fn create_lib(
                             msg: format!(
                                 "unrecognised archive member at {:#x} in {}",
                                 member.file_range().0,
-                                lib_path.display()
+                                from_lib.display()
                             ),
                             cause: e,
                         });
@@ -165,9 +167,6 @@ fn create_lib(
 }
 
 fn list_lib(lib_path: &OsStr) -> Result<(), WinlibError> {
-    // TODO: options show size and symbols for each member
-    // As well as the archive's symbol table.
-
     let data = fs::read(&lib_path).map_err(|e| WinlibError::IoError {
         msg: format!("cannot read {}", lib_path.display()),
         cause: e,
@@ -191,174 +190,67 @@ fn list_lib(lib_path: &OsStr) -> Result<(), WinlibError> {
     Ok(())
 }
 
-#[derive(PartialEq)]
-enum Command {
-    Create,
-    List,
-}
-
-#[derive(Default)]
-struct Options {
-    command: Option<Command>,
-    exclude_idata: bool,
-    exclude_offsets: Vec<u32>,
-    from_lib: Option<OsString>,
-    target_lib: Option<OsString>,
-    save_excluded: Option<OsString>,
-    help: bool,
-}
-
-fn parse_args() -> Result<Options, lexopt::Error> {
-    let mut options = Options::default();
-    let mut parser = lexopt::Parser::from_env();
-    let mut first = true;
-    let mut unexpected = None;
-    while let Some(arg) = parser.next()? {
-        use lexopt::Arg::{Long, Short, Value};
-        match arg {
-            Short('h') | Long("help") => {
-                options.help = true;
-                return Ok(options);
-            }
-            Value(ref v) if first => {
-                if v == "create" {
-                    options.command = Some(Command::Create);
-                } else if v == "list" {
-                    options.command = Some(Command::List);
-                } else {
-                    if unexpected.is_none() {
-                        unexpected = Some(arg.unexpected());
-                    }
-                }
-            }
-            _ if first => {
-                if unexpected.is_none() {
-                    unexpected = Some(arg.unexpected());
-                }
-            }
-            Value(v) if options.target_lib.is_none() => options.target_lib = Some(v),
-            Long("from") if options.command == Some(Command::Create) => {
-                options.from_lib = Some(parser.value()?);
-            }
-            Long("save-excluded") | Long("keep-removed")
-                if options.command == Some(Command::Create) =>
-            {
-                options.save_excluded = Some(parser.value()?);
-            }
-            Long("exclude") | Long("remove") if options.command == Some(Command::Create) => {
-                let value = parser.value()?;
-                let offset = match value.to_str() {
-                    Some(s) => if s.starts_with("0x") {
-                        u32::from_str_radix(&s[2..], 16)
-                    } else {
-                        u32::from_str_radix(s, 10)
-                    }
-                    .map_err(|_| lexopt::Error::ParsingFailed {
-                        value: s.into(),
-                        error: "value must be an offset in hexadecimal or decimal format".into(),
-                    })?,
-                    None => {
-                        if unexpected.is_none() {
-                            unexpected = Some(lexopt::Error::NonUnicodeValue(value));
-                        }
-                        continue;
-                    }
-                };
-                options.exclude_offsets.push(offset);
-            }
-            Long("exclude-idata") | Long("remove-idata")
-                if options.command == Some(Command::Create) =>
-            {
-                options.exclude_idata = true;
-            }
-            _ => {
-                if unexpected.is_none() {
-                    unexpected = Some(arg.unexpected());
-                }
-            }
-        }
-        first = false;
-    }
-    if let Some(unexpected) = unexpected {
-        return Err(unexpected);
-    }
-    Ok(options)
-}
-
-fn print_help() {
-    println!(
-        "Usage:
-\twinlib list <LIB_PATH>
-\twinlib create <LIB_PATH> --from <PATH> --exclude-idata [--save-excluded <PATH>]
-
-<LIB_PATH> is the path of the lib to create or inspect.
-
-Create Options:
-\t--from <PATH>        \tThe new lib will contain members from the old lib at <PATH>.
-\t--exclude <OFFSET>    \tExclude the member at the given offset
-\t--exclude-idata       \tExclude members containing .idata sections.
-\t--save-excluded <PATH>\tStore the excluded members in a separate library at <PATH>.
-
-Examples:
-\twinlib list oldlib.lib
-\twinlib create newlib.lib --from oldlib.lib --exclude-idata --save-excluded import.lib
-"
-    );
-}
-
-fn println(args: fmt::Arguments<'_>) {
-    let mut out = io::stdout().lock();
-    _ = out.write_fmt(args);
-    _ = out.write(b"\n");
-}
-
-macro_rules! failure {
-    ($($arg:tt)*) => {{
-        println(std::format_args!($($arg)*));
-        ExitCode::FAILURE
-    }};
-}
-
 fn main() -> ExitCode {
-    let options = match parse_args() {
-        Ok(options) => options,
-        Err(e) => {
-            return failure!("\nerror {e}");
-        }
-    };
-    if options.help {
-        print_help();
-        return ExitCode::SUCCESS;
+    use clap::{arg, builder::ValueParser};
+    fn hex_value(s: &str) -> Result<u32, ParseIntError> {
+        let offset = if let Some(s) = s.strip_prefix("0x") {
+            u32::from_str_radix(s, 16)
+        } else {
+            u32::from_str_radix(s, 10)
+        }?;
+        Ok(offset)
     }
-    let Some(target_lib) = options.target_lib else {
-        print_help();
-        return failure!("error: no output lib path provided");
-    };
-    match options.command {
-        Some(Command::Create) => {
-            let Some(lib_path) = options.from_lib else {
-                print_help();
-                return failure!("error: no --from lib path provided");
-            };
+    let matches = clap::Command::new("winlib")
+        .version("0.2.1")
+        .propagate_version(true)
+        .subcommand_required(true)
+        .arg_required_else_help(true)
+        .subcommand(clap::Command::new("list")
+            .about("Show the contents of a lib.")
+            .arg(arg!([LIB_PATH] "the path of the lib to inspect").value_parser(ValueParser::os_string())))
+        .subcommand(
+            clap::Command::new("create")
+                .about("Create a new lib from an old lib.")
+                .arg(arg!(<LIB_PATH> "the new path of the lib to create").required(true).value_parser(ValueParser::os_string()))
+                .arg(arg!(--from <PATH> "The new lib will contain members from the old lib at <PATH>.").required(true).value_parser(ValueParser::os_string()))
+                // FIXME: use a custom value parser
+                .arg(arg!(--exclude <OFFSET> "Exclude the member at the given offset.").value_parser(hex_value).action(ArgAction::Append))
+                .arg(arg!(--"exclude-idata" "Exclude members containing .idata sections."))
+                .arg(arg!(--"save-excluded" <PATH> "Store the excluded members in a separate library at <PATH>.").value_parser(ValueParser::os_string()))
+        )
+        .get_matches();
+
+    match matches.subcommand() {
+        Some(("create", cfg)) => {
+            let Some(target_lib) = cfg.get_one::<OsString>("LIB_PATH") else { unreachable!() };
+            let Some(from_lib) = cfg.get_one::<OsString>("from") else { unreachable!() };
+            let exclude_offsets: Vec<u32> =
+                cfg.get_many("exclude").unwrap_or_default().copied().collect();
+            let exclude_idata = cfg.get_flag("exclude-idata");
+            let save_excluded = cfg.get_one::<OsString>("save-excluded");
             let options = CreateOptions {
-                exclude_offsets: options.exclude_offsets,
-                exclude_idata: options.exclude_idata,
-                save_excluded: options.save_excluded,
+                exclude_offsets,
+                exclude_idata,
+                save_excluded: save_excluded.cloned(),
             };
-            match create_lib(&lib_path, &target_lib, &options) {
+            match create_lib(from_lib, target_lib, &options) {
                 Ok(_) => return ExitCode::SUCCESS,
                 Err(e) => {
                     eprintln!("error: {e}")
                 }
             }
         }
-        Some(Command::List) => match list_lib(&target_lib) {
-            Ok(_) => return ExitCode::SUCCESS,
-            Err(e) => {
-                eprintln!("error: {e}")
+        Some(("list", cfg)) => {
+            let Some(target_lib) = cfg.get_one::<OsString>("LIB_PATH") else { unreachable!() };
+            match list_lib(target_lib) {
+                Ok(_) => return ExitCode::SUCCESS,
+                Err(e) => {
+                    eprintln!("error: {e}")
+                }
             }
-        },
-        _ => {}
+        }
+        _ => (),
     }
-    ExitCode::SUCCESS
+
+    ExitCode::FAILURE
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ fn create_lib(
     options: &CreateOptions,
 ) -> Result<(), WinlibError> {
     let extracted_lib = options.save_excluded.as_deref();
-    let data = fs::read(&from_lib).map_err(|e| WinlibError::IoError {
+    let data = fs::read(from_lib).map_err(|e| WinlibError::IoError {
         msg: format!("cannot read {}", from_lib.display()),
         cause: e,
     })?;
@@ -70,7 +70,7 @@ fn create_lib(
         if options.exclude_offsets.contains(&(member.file_range().0 as u32)) {
             exclude = true;
         } else if options.exclude_idata {
-            match CoffFile::<_, ImageFileHeader>::parse(&*data) {
+            match CoffFile::<_, ImageFileHeader>::parse(data) {
                 Ok(file) => {
                     let strings = file.coff_symbol_table().strings();
                     for section in file.coff_section_table().iter() {
@@ -89,7 +89,7 @@ fn create_lib(
                     }
                 }
                 Err(e) => {
-                    if let Ok(_) = ImportFile::parse(&*data) {
+                    if ImportFile::parse(data).is_ok() {
                         exclude = true;
                     } else {
                         // maybe we should just warn here?
@@ -138,7 +138,7 @@ fn create_lib(
             msg: "could not create new library file".into(),
             cause: e,
         })?;
-        fs::write(lib, &writer.get_ref()).map_err(|e| WinlibError::IoError {
+        fs::write(lib, writer.get_ref()).map_err(|e| WinlibError::IoError {
             msg: format!("unable to write library to {}", lib.display()),
             cause: e,
         })?;
@@ -158,7 +158,7 @@ fn create_lib(
         msg: "could not create new library file".into(),
         cause: e,
     })?;
-    fs::write(out_lib, &writer.get_ref()).map_err(|e| WinlibError::IoError {
+    fs::write(out_lib, writer.get_ref()).map_err(|e| WinlibError::IoError {
         msg: format!("unable to write library to {}", out_lib.display()),
         cause: e,
     })?;
@@ -167,7 +167,7 @@ fn create_lib(
 }
 
 fn list_lib(lib_path: &OsStr) -> Result<(), WinlibError> {
-    let data = fs::read(&lib_path).map_err(|e| WinlibError::IoError {
+    let data = fs::read(lib_path).map_err(|e| WinlibError::IoError {
         msg: format!("cannot read {}", lib_path.display()),
         cause: e,
     })?;


### PR DESCRIPTION
I think this might be overkill for my use case but it does allow for easier and more confident changes. I can revisit this before 1.0. It does currently appear to be a substantial portion of the final binary size but maybe I can bring that down again.